### PR TITLE
Update coding path on decode/encode value

### DIFF
--- a/Sources/Decoder/DictionaryKeyedDecodingContainer.swift
+++ b/Sources/Decoder/DictionaryKeyedDecodingContainer.swift
@@ -9,7 +9,7 @@ internal class DictionaryKeyedDecodingContainer<Key: CodingKey>:
     internal let components: [String: Any]
     internal let options: DictionaryDecodingOptions
     internal let userInfo: [CodingUserInfoKey: Any]
-    internal let codingPath: [CodingKey]
+    internal private(set) var codingPath: [CodingKey]
 
     internal var allKeys: [Key] {
         components.keys.compactMap { Key(stringValue: $0) }
@@ -74,63 +74,108 @@ internal class DictionaryKeyedDecodingContainer<Key: CodingKey>:
     }
 
     internal func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode(_ type: String.Type, forKey key: Key) throws -> String {
-        try decodeComponentValue(try component(forKey: key))
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key))
     }
 
     internal func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
-        try decodeComponentValue(try component(forKey: key), as: type)
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return try decodeComponentValue(try component(forKey: key), as: type)
     }
 
     internal func nestedContainer<NestedKey: CodingKey>(

--- a/Sources/Encoder/DictionaryKeyedEncodingContainer.swift
+++ b/Sources/Encoder/DictionaryKeyedEncodingContainer.swift
@@ -7,6 +7,7 @@ internal final class DictionaryKeyedEncodingContainer<Key: CodingKey>:
     // MARK: - Instance Properties
 
     internal let container: DictionaryAnyKeyedEncodingContainer
+    internal private(set) var codingPath: [CodingKey]
 
     internal var options: DictionaryEncodingOptions {
         container.options
@@ -16,14 +17,11 @@ internal final class DictionaryKeyedEncodingContainer<Key: CodingKey>:
         container.userInfo
     }
 
-    internal var codingPath: [CodingKey] {
-        container.codingPath
-    }
-
     // MARK: - Initializers
 
     internal init(container: DictionaryAnyKeyedEncodingContainer) {
         self.container = container
+        self.codingPath = container.codingPath
     }
 
     // MARK: - Instance Methods
@@ -77,11 +75,17 @@ internal final class DictionaryKeyedEncodingContainer<Key: CodingKey>:
     }
 
     internal func encode(_ value: Double, forKey key: Key) throws {
-        container.collectComponent(try encodeComponentValue(value), forKey: key)
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return container.collectComponent(try encodeComponentValue(value), forKey: key)
     }
 
     internal func encode(_ value: Float, forKey key: Key) throws {
-        container.collectComponent(try encodeComponentValue(value), forKey: key)
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return container.collectComponent(try encodeComponentValue(value), forKey: key)
     }
 
     internal func encode(_ value: String, forKey key: Key) throws {
@@ -89,7 +93,10 @@ internal final class DictionaryKeyedEncodingContainer<Key: CodingKey>:
     }
 
     internal func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
-        container.collectComponent(try encodeComponentValue(value), forKey: key)
+        codingPath.append(key)
+        defer { codingPath.removeLast() }
+
+        return container.collectComponent(try encodeComponentValue(value), forKey: key)
     }
 
     internal func nestedContainer<NestedKey: CodingKey>(

--- a/Tests/Decoder/DictionaryDecoderTests.swift
+++ b/Tests/Decoder/DictionaryDecoderTests.swift
@@ -704,6 +704,143 @@ final class DictionaryDecoderTests: XCTestCase, DictionaryDecoderTesting {
         }
     }
 
+    // MARK: -
+
+    func testNestedCodingPathAppending() throws {
+        struct DoubleNestedDecodableStruct: Decodable {
+            enum CodingKeys: String, CodingKey {
+                case doubleNestedFoo
+                case doubleNestedBar
+            }
+
+            let doubleNestedFoo: Int
+            let doubleNestedBar: Int
+            var actualCodingPath: [CodingKey] = []
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+
+                actualCodingPath = decoder.codingPath
+                doubleNestedFoo = try container.decode(Int.self, forKey: .doubleNestedFoo)
+                doubleNestedBar = try container.decode(Int.self, forKey: .doubleNestedBar)
+            }
+        }
+
+        struct NestedDecodableStruct: Decodable {
+            enum CodingKeys: String, CodingKey {
+                case nestedFoo
+                case nestedBar
+                case doubleNested
+            }
+
+            let nestedFoo: Int
+            let nestedBar: Int
+            let doubleNested: DoubleNestedDecodableStruct
+        }
+
+        struct DecodableStruct: Decodable {
+            enum CodingKeys: String, CodingKey {
+                case foo
+                case bar
+                case nested
+            }
+
+            let foo: Int
+            let bar: Int
+            let nested: NestedDecodableStruct
+        }
+
+        let expectedCodingPath: [CodingKey] = [
+            DecodableStruct.CodingKeys.nested,
+            NestedDecodableStruct.CodingKeys.doubleNested
+        ]
+
+        let dictionary: [String: Any] = [
+            "foo": 123,
+            "bar": 456,
+            "nested": [
+                "nestedFoo": 789,
+                "nestedBar": 111,
+                "doubleNested": [
+                    "doubleNestedFoo": 222,
+                    "doubleNestedBar": 333
+                ]
+            ]
+        ]
+
+        let result = try decoder.decode(DecodableStruct.self, from: dictionary)
+
+        XCTAssertEqual(
+            expectedCodingPath.map { $0.stringValue },
+            result.nested.doubleNested.actualCodingPath.map { $0.stringValue }
+        )
+    }
+
+    func testNestedCodingPathRemoval() throws {
+        struct DoubleNestedDecodableStruct: Decodable {
+            let doubleNestedFoo: Int
+            let doubleNestedBar: Int
+        }
+
+        struct NestedDecodableStruct: Decodable {
+            enum CodingKeys: String, CodingKey {
+                case nestedFoo
+                case nestedBar
+                case doubleNested
+            }
+
+            let nestedFoo: Int
+            let nestedBar: Int
+            let doubleNested: DoubleNestedDecodableStruct
+            var actualCodingPath: [CodingKey] = []
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+
+                nestedFoo = try container.decode(Int.self, forKey: .nestedFoo)
+                nestedBar = try container.decode(Int.self, forKey: .nestedBar)
+                doubleNested = try container.decode(DoubleNestedDecodableStruct.self, forKey: .doubleNested)
+                actualCodingPath = decoder.codingPath
+            }
+        }
+
+        struct DecodableStruct: Decodable {
+            enum CodingKeys: String, CodingKey {
+                case foo
+                case bar
+                case nested
+            }
+
+            let foo: Int
+            let bar: Int
+            let nested: NestedDecodableStruct
+        }
+
+        let expectedCodingPath: [CodingKey] = [
+            DecodableStruct.CodingKeys.nested
+        ]
+
+        let dictionary: [String: Any] = [
+            "foo": 123,
+            "bar": 456,
+            "nested": [
+                "nestedFoo": 789,
+                "nestedBar": 111,
+                "doubleNested": [
+                    "doubleNestedFoo": 222,
+                    "doubleNestedBar": 333
+                ]
+            ]
+        ]
+
+        let result = try decoder.decode(DecodableStruct.self, from: dictionary)
+
+        XCTAssertEqual(
+            expectedCodingPath.map { $0.stringValue },
+            result.nested.actualCodingPath.map { $0.stringValue }
+        )
+    }
+
     // MARK: - XCTestCase
 
     override func setUp() {

--- a/Tests/Encoder/DictionaryEncoderTests.swift
+++ b/Tests/Encoder/DictionaryEncoderTests.swift
@@ -548,6 +548,141 @@ final class DictionaryEncoderTests: XCTestCase, DictionaryEncoderTesting {
         }
     }
 
+    // MARK: -
+
+    func testNestedCodingPathAppending() throws {
+        struct DoubleNestedDecodableStruct: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case doubleNestedFoo
+                case doubleNestedBar
+            }
+
+            private(set) static var actualCodingPath: [CodingKey] = []
+
+            let doubleNestedFoo: Int
+            let doubleNestedBar: Int
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+
+                try container.encode(doubleNestedFoo, forKey: .doubleNestedFoo)
+                try container.encode(doubleNestedBar, forKey: .doubleNestedBar)
+
+                Self.actualCodingPath = encoder.codingPath
+            }
+        }
+
+        struct NestedDecodableStruct: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case nestedFoo
+                case nestedBar
+                case doubleNested
+            }
+
+            let nestedFoo: Int
+            let nestedBar: Int
+            let doubleNested: DoubleNestedDecodableStruct
+        }
+
+        struct DecodableStruct: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case foo
+                case bar
+                case nested
+            }
+
+            let foo: Int
+            let bar: Int
+            let nested: NestedDecodableStruct
+        }
+
+        let expectedCodingPath: [CodingKey] = [
+            DecodableStruct.CodingKeys.nested,
+            NestedDecodableStruct.CodingKeys.doubleNested
+        ]
+
+        let decodableStruct = DecodableStruct(
+            foo: 111,
+            bar: 222,
+            nested: NestedDecodableStruct(
+                nestedFoo: 333,
+                nestedBar: 444,
+                doubleNested: DoubleNestedDecodableStruct(doubleNestedFoo: 555, doubleNestedBar: 666)
+            )
+        )
+
+        _ = try encoder.encode(decodableStruct)
+
+        XCTAssertEqual(
+            expectedCodingPath.map { $0.stringValue },
+            DoubleNestedDecodableStruct.actualCodingPath.map { $0.stringValue }
+        )
+    }
+
+    func testNestedCodingPathRemoval() throws {
+        struct DoubleNestedDecodableStruct: Encodable {
+            let doubleNestedFoo: Int
+            let doubleNestedBar: Int
+        }
+
+        struct NestedDecodableStruct: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case nestedFoo
+                case nestedBar
+                case doubleNested
+            }
+
+            private(set) static var actualCodingPath: [CodingKey] = []
+
+            let nestedFoo: Int
+            let nestedBar: Int
+            let doubleNested: DoubleNestedDecodableStruct
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+
+                try container.encode(nestedFoo, forKey: .nestedFoo)
+                try container.encode(nestedBar, forKey: .nestedBar)
+                try container.encode(doubleNested, forKey: .doubleNested)
+
+                Self.actualCodingPath = encoder.codingPath
+            }
+        }
+
+        struct DecodableStruct: Encodable {
+            enum CodingKeys: String, CodingKey {
+                case foo
+                case bar
+                case nested
+            }
+
+            let foo: Int
+            let bar: Int
+            let nested: NestedDecodableStruct
+        }
+
+        let expectedCodingPath: [CodingKey] = [
+            DecodableStruct.CodingKeys.nested
+        ]
+
+        let decodableStruct = DecodableStruct(
+            foo: 111,
+            bar: 222,
+            nested: NestedDecodableStruct(
+                nestedFoo: 333,
+                nestedBar: 444,
+                doubleNested: DoubleNestedDecodableStruct(doubleNestedFoo: 555, doubleNestedBar: 666)
+            )
+        )
+
+        _ = try encoder.encode(decodableStruct)
+
+        XCTAssertEqual(
+            expectedCodingPath.map { $0.stringValue },
+            NestedDecodableStruct.actualCodingPath.map { $0.stringValue }
+        )
+    }
+
     // MARK: - XCTestCase
 
     override func setUp() {


### PR DESCRIPTION
## Problem
When decoding and encoding values coding path is not appended. For this reason, coding path will be empty in error descriptions and in methods `init(from:)`, `encode(to:)`.

## Solution
Updating coding path on `decode` and `encode` methods of `KeyedDecodingContainerProtocol` and `KeyedEncodingContainerProtocol` respectively.
Also added unit tests for testing appending and removal coding path correctly.