### PR TITLE
feat: new strategy to skip encoding nested containers

### DIFF
--- a/Sources/Encoder/DictionaryComponentEncoder.swift
+++ b/Sources/Encoder/DictionaryComponentEncoder.swift
@@ -208,6 +208,9 @@ extension DictionaryComponentEncoder {
         case let url as URL:
             return try encodeURL(url, at: codingPath)
 
+        case _ where self.options.nestedEncodingStrategy == .skip:
+            return .value(nil)
+
         default:
             return try encodeNonPrimitiveValue(value, at: codingPath)
         }

--- a/Sources/Encoder/DictionaryEncoder.swift
+++ b/Sources/Encoder/DictionaryEncoder.swift
@@ -32,6 +32,11 @@ public final class DictionaryEncoder: Sendable {
         set { optionsMutex.withLock { $0.keyEncodingStrategy = newValue } }
     }
 
+    public var nestedEncodingStrategy: DictionaryNestedEncodingStrategy {
+        get { optionsMutex.withLock { $0.nestedEncodingStrategy } }
+        set { optionsMutex.withLock { $0.nestedEncodingStrategy = newValue } }
+    }
+
     public var userInfo: [CodingUserInfoKey: Sendable] {
         get { userInfoMutex.withLock { $0 } }
         set { userInfoMutex.withLock { $0 = newValue } }
@@ -45,6 +50,7 @@ public final class DictionaryEncoder: Sendable {
         nonConformingFloatEncodingStrategy: DictionaryNonConformingFloatEncodingStrategy = .throw,
         nilEncodingStrategy: DictionaryNilEncodingStrategy = .useNil,
         keyEncodingStrategy: DictionaryKeyEncodingStrategy = .useDefaultKeys,
+        nestedEncodingStrategy: DictionaryNestedEncodingStrategy = .encode,
         userInfo: [CodingUserInfoKey: Sendable] = [:]
     ) {
         let options = DictionaryEncodingOptions(
@@ -52,7 +58,8 @@ public final class DictionaryEncoder: Sendable {
             dataEncodingStrategy: dataEncodingStrategy,
             nonConformingFloatEncodingStrategy: nonConformingFloatEncodingStrategy,
             nilEncodingStrategy: nilEncodingStrategy,
-            keyEncodingStrategy: keyEncodingStrategy
+            keyEncodingStrategy: keyEncodingStrategy,
+            nestedEncodingStrategy: nestedEncodingStrategy
         )
 
         self.optionsMutex = Mutex(value: options)

--- a/Sources/Encoder/Options/DictionaryEncodingOptions.swift
+++ b/Sources/Encoder/Options/DictionaryEncodingOptions.swift
@@ -9,4 +9,5 @@ internal struct DictionaryEncodingOptions {
     internal var nonConformingFloatEncodingStrategy: DictionaryNonConformingFloatEncodingStrategy
     internal var nilEncodingStrategy: DictionaryNilEncodingStrategy
     internal var keyEncodingStrategy: DictionaryKeyEncodingStrategy
+    internal var nestedEncodingStrategy: DictionaryNestedEncodingStrategy
 }

--- a/Sources/Encoder/Options/DictionaryNestedEncodingStrategy.swift
+++ b/Sources/Encoder/Options/DictionaryNestedEncodingStrategy.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public enum DictionaryNestedEncodingStrategy: Sendable {
+
+    // MARK: - Enumeration Cases
+
+    case encode
+    case skip
+}

--- a/Tests/Encoder/DictionaryEncoderStrategiesTests.swift
+++ b/Tests/Encoder/DictionaryEncoderStrategiesTests.swift
@@ -219,6 +219,25 @@ final class DictionaryEncoderStrategiesTests: XCTestCase, DictionaryEncoderTesti
         assertEncoderSucceeds(encoding: EncodableStruct())
     }
 
+    // MARK: -
+
+    func testThatEncoderSucceedsWhenSkippingNestedContainers() {
+        struct EncodableStruct: Encodable {
+            var test: String = "1"
+            var dict: [String: Int] = ["a": 1]
+            var array: [String] = ["b"]
+        }
+
+        encoder.nestedEncodingStrategy = .skip
+
+        assertEncoderSucceeds(
+            encoding: EncodableStruct(),
+            expecting: [
+                "test": "1"
+            ])
+    }
+
+
     // MARK: - XCTestCase
 
     override func setUp() {


### PR DESCRIPTION
Hello! 

I have a strange use-case that is not currently covered by your very nice library :) I'm in the process of integrating Customer.io in my app, but they recently deprecated the possibility to send Codable models to their API because they don't support having nested containers as values for user traits.

[Customer.io SDK changelog](https://docs.customer.io/integrations/sdk/ios/whats-new/3.13.0-upgrade/#:~:text=Identifying%20a%20user,anonymous%20profile%20attributes)

The pattern I've been using successfully with other analytics libraries is to define a Codable user properties model and then using DictionaryCoder to make a `[String: Any]` value to send to these APIs, but now Customer.io requires me to basically skip nested containers. I could iterate the output of the encoder to remove the extra fields, but I feel like that's a more brittle solution than adding an option to the dictionary encoder.

I added a strategy to the configuration options for the dictionary encoder for this purpose. Thank you again for making this very useful library.

(No AI was involved in making any part of this PR.)